### PR TITLE
Make (temporarily () body ...) expand to (let () body ...).

### DIFF
--- a/lib/control-features.sls
+++ b/lib/control-features.sls
@@ -1237,7 +1237,7 @@
   (define-syntax/who temporarily
     (lambda (x)
       (syntax-case x ()
-        [(_ () b1 b2 ...) #'(begin b1 b2 ...)]
+        [(_ () b1 b2 ...) #'(let () b1 b2 ...)]
         [(_ ([x e] ...) b1 b2 ...)
          (with-syntax ([(p ...) (generate-temporaries #'(x ...))]
                        [(y ...) (generate-temporaries #'(x ...))])


### PR DESCRIPTION
It should not be a splicing construct.