### PR TITLE
Fix errata: The first example of `temporarily` should return 3.

### DIFF
--- a/srfi-226.html
+++ b/srfi-226.html
@@ -2361,7 +2361,7 @@
 
     <pre class=example>(let ([p (make-parameter 1 (lambda (x) (+ x 1)))])
   (temporarily ([p 4]) (values))
-  (p))<span class=result>5</span>
+  (p))<span class=result>3</span>
 
 (let ([p (make-parameter 1 (lambda (x) (+ x 1)))])
   (parameterize ([p 4]) (values))


### PR DESCRIPTION
This is also reflected in the test suites.

